### PR TITLE
This handles using html_path from a remote site, manually setting site=localhost:3000 for example, and makes sure that the correct site is respected, and the redirect returned includes the site= again

### DIFF
--- a/wagtail/api/v2/views.py
+++ b/wagtail/api/v2/views.py
@@ -112,7 +112,8 @@ class BaseAPIViewSet(GenericViewSet):
                     self.__class__.__name__
                 )
             )
-
+        if "site" in request.GET:
+            return redirect(url + "?site=" + request.GET["site"])
         return redirect(url)
 
     def find_object(self, queryset, request):


### PR DESCRIPTION
Added redirect

Fixes #...

This handles using html_path from a remote site, manually setting site=localhost:3000 for example, and makes sure that the correct site is respected, and the redirect returned includes the site= again







_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
